### PR TITLE
Adds Zenodo badge to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.project
+.DS_Store
+*.iml
+*.html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14015294.svg)](https://doi.org/10.5281/zenodo.14015294)
+
+
 # DAP4 Specification
 
 This repository serves two greater purposes:

--- a/travis/deploy_to_gh_pages.sh
+++ b/travis/deploy_to_gh_pages.sh
@@ -28,6 +28,15 @@ EOF
 # Here we add an index.html that redirects to DMRpp.html
 echo "${index_html}" | tee index.html
 
+sed -i '/<\/head>/i\
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-C166YERTXV"></script>\
+<script>\
+window.dataLayer = window.dataLayer || [];\
+function gtag(){dataLayer.push(arguments);}\
+gtag("js", new Date());\
+gtag("config", "G-C166YERTXV");\
+</script>' DAP4.html
+
 # Now we set up the git repo
 git config --global init.defaultBranch "main"
 git init


### PR DESCRIPTION
This PR:
- [x] Closes #17 by adding a zenodo badge to the readme. 
- [x] Adds a GA tag during build process before deployment ( for metrics).
- [x] Adds .gitignore so that from now on, no html files are push (only source files)
