### PR TITLE
Remove nested sections within Overview.adoc

### DIFF
--- a/Overview.adoc
+++ b/Overview.adoc
@@ -26,7 +26,7 @@ building clients and servers with greater interoperability, making such
 ventures more rewarding and less risky.
 
 
-== Data Retrieval as a Web Service ==
+[.blue]#Data Retrieval as a Web Service#::
 
 The premise underlying DAP4 remains, as in DAP2, that values from data
 sources—or, notably, from proper subsets—along with pertinent metadata
@@ -39,7 +39,7 @@ connectivity. OPeNDAP’s commitment to open source has fostered several
 DAP-compatible servers and an even larger number of DAP-compatible
 client environments, several of which (i.e., servers, clients and
 client-server libraries) are available at no cost.
-
++
 DAP is designed for selectively retrieving (but not for storing) data
 organized as variables or groups of variables. It is well suited to
 cases where client computers retrieve data stored on remote computers
@@ -48,7 +48,7 @@ are huge (comprising large arrays, e.g.) but clients typically need only
 small subsets of them. The protocol is fundamentally stateless (some
 might say "`RESTful`"), and it governs how clients pose requests and how
 servers issue corresponding responses.
-
++
 DAP’s effectiveness is keyed on the underlying data model, which
 embraces a rich variety of data types (including tabular and array
 structures). Based on this model, DAP spells out the (type-specific)
@@ -60,10 +60,10 @@ Stated another way, many kinds of data sources and schemas can be mapped
 onto the DAP model for retrieval and use by client computers and
 software.
 
-== Understanding the DAP Data Model ==
-
-=== A Brief Data-Model Summary ===
-
+[.blue]#Understanding the DAP Data Model#::
++
+. *A Brief Data-Model Summary*
++
 Unlike FTP and other protocols enabling clients to access whole files or
 granules, DAP offers sub-granular retrievals, and this requires exposing
 the detailed structure of each granule (called a "`dataset`" in DAP). To
@@ -72,7 +72,7 @@ machine-readable document called the DMR. DMRs are declaration
 statements that adhere formally to the DAP Data Model, which is
 sufficiently general to make retrievable a variety of data granules and
 data types whose semantics vary widely among the (potential) sources.
-
++
 The DAP data model is built around a notion of "`variables`" that fall
 into three classes—atoms, structures and sequences—and may be organized
 as multidimensional arrays. As reflected in its DMR, all of a dataset’s
@@ -83,7 +83,7 @@ and "`dimensions`", the former to clarify meaning and the latter to
 indicate a variable’s array shape (where relevant). Attributes resemble
 variables except that the former may be assigned to the latter, but not
 vice versa.
-
++
 Much of DAP’s power arises from its typing structure. The value(s) of an
 atomic variable (whether or not dimensioned as an array) are all of the
 same atomic type, indicated in the DMR to be integer, floating point,
@@ -91,7 +91,7 @@ character, string, etc. Structure variables are combinations of atom
 variables joined for semantic reasons, such as to represent complex
 numbers, vector-valued parameters, or other relationships among the
 values of a dataset.
-
++
 To address a difficult abstraction challenge—retrievals from both
 array-oriented and database-oriented sources—DAP allows DMRs to declare
 variables of type "`Sequence`". A sequence is like a relation, i.e., a
@@ -99,7 +99,7 @@ table whose rows are "`instances`" or "`records`" and whose columns
 contain the values of "`fields`". In DAP, the content of a sequence may
 comprise an arbitrary number of instances (i.e., records) whose
 "`fields`" are values from other DAP variables.
-
++
 For example, a sequence named "`BirdTracking`" might contain variables
 named "`BirdID`", "`BandingEvent`", and "`ObservedPosition`", and the
 contents of BirdTracking would be instances that contain values of the
@@ -108,99 +108,103 @@ and structures, so in this example BandingEvent could be a structure
 (containing date and location info for the bird’s banding) and
 ObservedPosition could be a sequence (containing equivalent date and
 location info) whose instances represent subsequent bird observations.
-
++
 Hypothetically, this is akin to making BirdTracking a structure with a
 single dimension (though DAP does not allow arrays of indefinite
 length). However, selective retrieval from an array would require
 knowing the indices of desired instances, whereas a BirdTracking
 sequence allows filtering-style retrievals that select instances on the
 basis of their values.
-
-=== A Rough Glossary of Data-Model Entities ===
-
++
+. *A Rough Glossary of Data-Model Entities*
++
 Much about DAP may be discerned from a dictionary or glossary-like list
 of the key entities in its data model. Such a list follows, sequenced
 for ease of understanding (rather than alphabetically). These
 descriptions are not definitive, as the formal specification documents
 take precedence over anything stated here.
-
-*Data Source* - Though formally outside the DAP Data Model, the term
++
+[disc]
+* *Data Source* - Though formally outside the DAP Data Model, the term
 Data Source generally refers to all the datasets (see below) that may be
 retrieved via DAP from a single server, identified by its domain name.
 Servers sometimes offer (catalogs and/or inventories of) collections and
 sub-collections, but the DAP Data Model focuses on granular and
 sub-granular retrievals.
-
-*Dataset* - Sometimes called a "`granule`" in catalog/inventory
++
+* *Dataset* - Sometimes called a "`granule`" in catalog/inventory
 parlance, a DAP Dataset is represented by a unique (unadorned) URL, and
 is the highest-level entity (metadata as well as content) described by
 the DAP Data Model. Clients invoke retrieval operations by adorning the
 Dataset URL with suffixes and query strings interpreted by the server.
-
-*Declarations and the DMR* - For a specific Dataset, all aspects of the
++
+* *Declarations and the DMR* - For a specific Dataset, all aspects of the
 DAP Data Model (name assignments, structural definitions, etc) are
 governed by a formal declarations document. Created as part of making a
 Dataset DAP-retrievable, this document is dubbed the DMR (roughly:
 Dataset Metadata Response), and clients may retrieve DMRs alongside or
 independently of Dataset contents.
-
-*Name* - Most entities in the DAP Data Model may or must be named. With
++
+* *Name* - Most entities in the DAP Data Model may or must be named. With
 some constraints on the use of special characters (such as "`.`"), a
 Name can be any character string. To avoid conflicts, DAP has scoping
 rules. For example, a Variable and a Dimension may have the same Name
 without ambiguity, but two Variables can have the same Name only if they
 are declared in different Groups or structures.
-
-*Variable* - The building blocks for the DAP Data Model are Variables,
++
+* *Variable* - The building blocks for the DAP Data Model are Variables,
 which are strictly typed. Three classes of them (atoms, structures and
 sequences) are described separately below, but in actuality these are
 best distinguished by inspecting their Type declarations. Each Variable
 must be assigned a Type and a Name, and it may optionally have a number
 of Dimensions and Attributes, elaborated below.
-
-*Type* - Underpinning DAP’s "`container`" Types (Structure and Sequence,
++
+* *Type* - Underpinning DAP’s "`container`" Types (Structure and Sequence,
 implied above) are "`atomic`" Types akin to those of computer languages:
 bytes, integers, floating-point values, strings, and URLs, plus an enum
 type (permitting specified character strings, such as days of the week,
 to be treated as variable values) and an opaque type (permitting
 arbitrary blobs of bits). More detailed Type descriptions are provided
 in Volume I of the DAP specification.
-
-*(Atom) Variable* - A Variable whose Type is atomic (see above)
++
+* *(Atom) Variable* - A Variable whose Type is atomic (see above)
 comprises a single value or an array of values, and all its values are
 of the designated Type. A Variable is an array only if its declaration
 includes Dimensions, which determine the array’s shape and its
 element-ordering (see below).
-
-*(Structure) Variable* - A Variable of Type "`Structure`" is a container
++
+* *(Structure) Variable* - A Variable of Type "`Structure`" is a container
 for other variables, often implying relationships among them. For
 example, a structure Variable named "`Velocity`" might contain a pair of
 atom Variables (or fields) named "`x`" and "`y,`" representing
 components of a velocity vector. These components would be retrieved via
 their "`qualified`" Names, "`Velocity.x`" and "`Velocity.y`".
-
++
 _Notes on Structures:_
-
-* Structures may contain variables of any type, including other
++
+[circle]
+** Structures may contain variables of any type, including other
 structures.
-* A contained variable can be used in the context of several containers,
+** A contained variable can be used in the context of several containers,
 but these contexts create separate, independent instances.
-* If the semantics of a variable are altered by its context, it should
+** If the semantics of a variable are altered by its context, it should
 be separately declared in each relevant context. For example,
 declarations for the atoms "`Velocity.x`" and "`Displacement.x`" should
 be distinct and separate (falling within "`Velocity`" and
 "`Displacement`" declarations respectively) despite reuse of the name
 "`x`".
-* Though a dimensioned structure resembles a structure containing
+** Though a dimensioned structure resembles a structure containing
 dimensioned variables (with the same shapes), these are not equivalent,
 and the means for referencing them differ. For example, array element
 i,j would be referenced as:
-** Velocity[i,j].x if two dimensions are assigned to the Velocity
+[square]
+*** Velocity[i,j].x if two dimensions are assigned to the Velocity
 structure.
-** Velocity.x[i,j] if two dimensions are assigned to its x-component
+*** Velocity.x[i,j] if two dimensions are assigned to its x-component
 variable.
 
-*(Sequence) Variable* - A Variable of Type "`Sequence`" is a container
++
+* *(Sequence) Variable* - A Variable of Type "`Sequence`" is a container
 holding multiple (unordered) instances of other DAP Variables. For
 example, a sequence Variable named "`TracerParticle`" might contain a
 pair of structures named "`Velocity`" and "`Displacement`", each
@@ -209,23 +213,24 @@ instances of TracerParticle would be like a set of tabular records whose
 four fields, Displacement.x, Displacement.y, Velocity.x, and Velocity.y
 are retrieved via filter-style (rather than indexed) retrievals, as
 discussed in a later section on Constraints.
-
++
 _Notes on Sequences:_
-
-* Sequences may contain variables of any type, including other
++
+[circle]
+** Sequences may contain variables of any type, including other
 sequences.
-* Though a sequence is similar in some respects to a structure with a
+** Though a sequence is similar in some respects to a structure with a
 single (indexing) dimension, the differences are significant. For
 example, if a DAP server offers retrieval of records from a relational
 data base:
-* The most useful client retrievals may entail filtering based on the
+** The most useful client retrievals may entail filtering based on the
 values in the fields, and this yields indexing gaps. In other words,
 indexing may have little or no utility.
-* The number of records may be hidden or dynamic, so a dimension length
+** The number of records may be hidden or dynamic, so a dimension length
 cannot be calculated, and the order in which records are returned may be
 volatile.
-
-*Group* - The DAP Data Model has a hierarchical mechanism for grouping
++
+* *Group* - The DAP Data Model has a hierarchical mechanism for grouping
 Variables and carving out independent namespaces. Groups may be nested,
 and all but one must have Names, the exception being the root of the
 hierarchy, where the Dataset itself is a Group (needing no name).
@@ -233,55 +238,57 @@ Retrieving a Variable whose declaration falls within a Named Group
 requires use of its fully qualified name (FQN), such as
 GroupA.Group2.Velocity. Any Group (including the Dataset) may be
 assigned Attributes but not Dimensions.
-
-*Attribute* - Otherwise nearly indistinguishable from a Variable, an
++
+* *Attribute* - Otherwise nearly indistinguishable from a Variable, an
 Attribute must always be assigned to a specific Variable or Group. The
 purpose of Attributes is to provide context or add meaning to the
 assigned entities, whereas the purpose of Variables is to convey primary
 content. Retrieving an Attribute always requires prepending the name of
 the Variable or Group to which it is assigned, which implies that
 Attribute Names (such as "`Units`") enjoy unlimited reusability.
-
-*Dimension* - A Dimension must have a size and may have a Name. A
++
+* *Dimension* - A Dimension must have a size and may have a Name. A
 Variable of any type may optionally be assigned a number of Dimensions,
 in which case its (compound) values are organized and retrieved as an
 indexible array of rank n, where n is the number of assigned Dimensions.
-
++
 _Notes on Dimensions:_
-
-* Named Dimensions resemble named constants. Indeed, assigning a named
++
+[circle]
+** Named Dimensions resemble named constants. Indeed, assigning a named
 dimension to multiple variables (within the scope of a single group) has
 the same effect on each, giving definition to that variable’s array
 shape and array-element ordering.
-* Unlike attributes, dimensions often are declared outside the variables
+** Unlike attributes, dimensions often are declared outside the variables
 to which they are assigned. Groups may not accept dimension assignments,
 but groups limit the scope of the dimension names and sizes declared
 within them.
-* Dimensions names may be reused, with differing sizes across multiple
+** Dimensions names may be reused, with differing sizes across multiple
 groups.
-* The order of the dimension assignments in a variable declaration is
+** The order of the dimension assignments in a variable declaration is
 significant, as this determines the variable’s array-element ordering as
 well as its shape.
-* Retrieving a dimension may require prepending the name of the group in
+** Retrieving a dimension may require prepending the name of the group in
 which it was declared but never the name of a variable to which it has
 been assigned.
-* A Dimension’s size must be a positive integer less than 2^61.
-
-=== Higher-Level DAP Objects and Extensions ===
-
+** A Dimension’s size must be a positive integer less than 2^61.
++
+. *Higher-Level DAP Objects and Extensions*
++
 Shared Dimensions that serve to indicate relations between different
 arrays which can be used to build/represent Coverages…
-
++
 Note: Though adoption to-date has been most pronounced in Earth
 sciences, DAP’s data types and structures (with the possible exception
 of coverages, discussed in this section) are not at all specific to
 these disciplines, so we think DAP is positioned for effective use in
 many domains, scientific and otherwise.
 
-== Client Use of a DAP Data Source ==
 
-=== High-Level Info about DAP Datasets: the DMR ===
+[.blue]#Client Use of a DAP Data Source#::
 
+. *High-Level Info about DAP Datasets: the DMR*
++
 A client’s first step in selectively retrieving a data source often is
 to discern the character (i.e., its schema) by requesting what DAP calls
 the DMR (the data-source metadata response). A DMR provides a complete
@@ -291,20 +298,20 @@ discussed in the preceding two subsections. For ease of use in client
 software, the DMR adheres to a formal syntax and most often is delivered
 as an XML document, though other forms are anticipated as DAP4
 _extensions_.
-
++
 Though it is common to retrieve its DMR prior to requesting content from
 a data source, this is not the only option. Indeed, a "`Data Request`"
 under DAP returns both the DMR and the content (i.e., the _values_ of
 variables) for the designated data source, because the former is
 critical for interpreting the latter.
-
-=== Retrieving Content from DAP Datasets: Posing DAP Requests ===
-
++
+. *Retrieving Content from DAP Datasets: Posing DAP Requests*
++
 Under DAP, the requests clients make of servers, and the resulting
 server responses, are all governed by the protocol specification. As
 stated previously, the formal specification takes precedent over
 anything stated here.
-
++
 For each data source, a number of responses may elicited by a client,
 determined by adding a suffix and/or a query string to the basic URL for
 the desired data source. Passing the server a completely _unadorned_ URL
@@ -314,7 +321,7 @@ include provision of a DMR and provision of _content_ from the source.
 Unlike the DMR, which is always textual, content (delivered in response
 to a Data Request, as discussed above) may be conveyed in textual _or_
 binary form, the latter minimizing data-transfer volumes, of course.
-
++
 If the URL for a Data Request includes a query string, the server parses
 this string to determine what data processing the server should perform
 before constructing its Data Response. Though other classes of
@@ -323,13 +330,13 @@ extensions, two forms are mandated by DAP4 for all servers, Index
 Subsetting and Field Subsetting, and a third form, Filtering, is defined
 in the core DAP specification, though its implementation by servers is
 optional.
-
++
 *Index Subsetting* - Choosing parts of an array based on the indexes of
 that array’s dimensions. This operation always returns an array of the
 same rank as the original, although the size of the return array will
 (likely) be smaller. Index subsetting uses the bracket syntax described
 later.
-
++
 *Field Subsetting* - Choosing specific variables or fields from the
 dataset. A dataset in DAP4 is made up of a number of variables and those
 may be Structures or Sequences that contain fields (and, in effect, the
@@ -337,14 +344,14 @@ Dataset is itself a Structure and all of its variables are fields - the
 distinction is more convenience than formal). Field subsetting using the
 brace syntax described later. One or more fields can be specified using
 a semicolon (;) as the separator.
-
++
 *Filtering* - A filter is a predicate that can be used to choose data
 elements based on their values. the vertical bar (|) is used as a prefix
 operator for the filter predicate. Filters can be applied to elements of
 an Array or fields of a Sequence. A filter predicate consists of one or
 more filter subexpressions. One or more subexpressions can be specified,
 using a comma (,) as the separator.
-
++
 Other services listed in the DSR might (at the server’s option) include
 the DAP Asynchronous Response. Where implemented (such as for near-line
 data sources), this response is sent to the client when the requested
@@ -352,19 +359,19 @@ resource (DMR, Data Response, etc.) is not immediately available. If, in
 turn, the client makes a "`retrieve it`" request, the server will
 respond with a second Asynchronous Response informing the client about
 when and where the requested resource may be retrieved.
-
++
 In addition to the most common data objects, a DAP server _may_ provide
 additional "`services,`" such as HTML-formatted representations of a
 data source’s structure and content. Such additional services are
 discussed in Volume 2 of the specification.
 
-== The Formal DAP Specification ==
-
+[.blue]#The Formal DAP Specification#::
++
 The DAP4 specification spans two volumes: one describes the Data Model
 and DAP’s Request/Response objects; the other volume describes how DAP
 clients and servers communicate via HTTP and the modern Web. New volumes
 about DAP Extensions will be added as they emerge.
-
++
 Partitioning the specification into two primary documents reflects the
 independence of DAP’s data-retrieval functionality from the underlying
 network transfer protocol. Indeed, DAP could be used with other
@@ -375,9 +382,9 @@ evolution of the protocol without the expense and complexity of another
 major protocol-development project. Anticipated extensions include a
 JSON encoding for DAP data/metadata and the provision of server
 functions (beyond DAP’s core subsetting and filtering operations).
-
++
 *The specification is available at these links:*
-
++
 * link:#Data_Model[Volume1: Data Model&#44; Persistent Representation&#44; and Constraints]
 * link:#Web_Services[Volume
 2: Web Services Specification]
@@ -388,12 +395,14 @@ Extension: CSV Data Encoding and Response]
 ** link:#netcdf-async[DAP4
 Extension: netCDF Asynchronous Response]
 
-== How DAP4 Differs from DAP2 ==
 
+[#_how_dap4_differs_from_dap2]
+[.blue]#How DAP4 Differs from DAP2#::
++
 [[dap2dap4]]
 .Differences in the data model and response types between DAP2 and DAP4. For a complete overview of differences, see text. 
 image::DAP4vsDAP2.png[width=750, align='center']
-
++
 This section covers changes to the data model, response formats, and
 serialization, giving developers a roadmap to migration from DAP2 to
 DAP4. E.g., the "`Grid`" type now supports a notion of discrete
@@ -402,7 +411,7 @@ Data Type found in Unidata’s Common Data Model (CDM). Also from this
 section, users may learn of functionalities to seek in clients. E.g.,
 DAP4 servers return checksums with each data response, but clients may
 utilize these in varying degrees.
-
++
 DAP4 is largely an extension of DAP2 concepts, is close to a superset of DAP2 (see xref:dap2dap4[Figure 1]),
 and includes ideas that emerged as DAP gained prominence across the Earth sciences. Therefore
 DAP2-compatible software, in clients or servers, should be easy to adapt
@@ -410,12 +419,12 @@ to DAP4, and this has been affirmed in the OPeNDAP-Unidata realization
 and testing work. Furthermore, DAP4 exhibits backward compatibility
 sufficient to enable gradual transitioning. Substantive changes include
 support for Groups, yielding greater compatibility with HDF and NetCDF4.
-
-=== Data-Model Changes ===
-
++
+. *Data-Model Changes*
++
 *Summary*: DAP4 now supports `Groups`, a generalized form of a grid
 datatype, adds a few new atomic types, but `Grids` are removed from the DAP4 Data model.
-
++
 The DAP4 data model is fundamentally similar to that for DAP2. New
 atomic types include: enumeration, 64-bit integer, and opaque, the
 container types removes `Grids` but now include Groups (see xref:dap2dap4[Figure 1]). 
@@ -423,7 +432,7 @@ In DAP4, a DAP2 `Grid` is represented by an `Array` together with information ab
 its `Dimensions` which may be shared, and `Maps` (see link:#_coverage_variables_and_maps[Coverage Variables and Maps]). Groups provide a way to organize collections 
 of variables and dimensions and to encode these organizational relationships when they 
 are present in the underlying source data.
-
++
 Dimensions may now be named, and the presence of shared dimensions
 (i.e., several variables employ a dimension with a given name) along
 with explicitly name '`maps`' serves to indicate relationships among
@@ -431,9 +440,9 @@ arrays that can, in turn, be used to build/represent a more general form
 of the DAP2 Grid datatype that resembles the OGC/ISO "`discrete
 coverage`" datatype. These '`discrete coverages`' subsume the role of
 DAP2 Grids, so the latter have been removed from DAP4.
-
++
 *Migrating from DAP2 to DAP4*
-
++
 For servers: A DAP2 DDS/DAS (or DDX) is very close to a DAP4 DMR
 (indeed, our C++ library contains a way to build a DMR from a DDS). The
 set of datatypes supported by DAP4 is almost a proper superset of those
@@ -444,15 +453,17 @@ retained and the appropriate Shared Dimension and Map elements are added
 to the dataset/group and array. Since the DAP4 '`discrete coverage`'
 type subsumes the DAP2 Grid, it will always be possible to translate a
 DAP2 Grid into DAP4.
-
++
 For clients: Some of the new data types are more challenging to
 implement than the types included with DAP2. Of particular note are
 Enumerations and the expanded grid (aka '`discrete coverage`') types.
++
+. *Changed Responses*
++
+--
+*Summary of the main changes between DAP2 and DAP4 Responses*:
 
-=== Changed Responses ===
-
-*Summary or the main changes between DAP2 and DAP4 Responses*:
-
+[disc]
 * DAP4 includes only one dataset _metadata_ response, the _DMR_ not two;
 * Several Sequences may be individually constrained in one access;
 * Predictable behavior for '`bare`' URLs; and
@@ -499,6 +510,7 @@ present an undue burden on some kinds of near-line devices.
 
 *Migrating from DAP2 to DAP4*
 
+[disc]
 * If your server or client already reads DAP2 DDX responses (which were
 never part of the official protocol but are widely used) then adapting
 to the _DMR_ will be very easy since they are very close in structure.
@@ -507,11 +519,14 @@ Constraint Expression and Server Functions have been separated.
 * Clients will benefit from asynchronous response support, but this is a
 new behavior and may take some serious thought, particularly for clients
 that relied on the simpler semantics borrowed from file system accesses.
+--
 
-=== Response-Encoding Changes ===
-
+. *Response-Encoding Changes*
++
+--
 *Summary*:
 
+[disc]
 * Checksums for data values;
 * Reliable delivery of error messages to clients;
 * Encode data using the server’s native word order.
@@ -536,10 +551,13 @@ byte order and twiddle bytes as needed. However, the server must
 correctly implement the chunking protocol used by the data response and
 must correctly computer CRC32 checksums for each of the top level
 variables.
+--
+. *Changes in the Use of HTTP*
++
+--
+*Summary*
 
-=== Changes in the Use of HTTP ===
-
-*Summary*: DAP4 is closer than DAP2 to the REST (Representational State
+DAP4 is closer than DAP2 to the REST (Representational State
 Transfer) architecture, and it uses HATEOS (Hypermedia As The Engine Of
 Application State), making all of the server’s responses explicit via
 links in a document.
@@ -577,9 +595,11 @@ clients should be modified to access data available only using this new
 feature. DAP4 also supports content negotiation and that means a larger
 number of ways to get the different responses (even though each protocol
 has three basic responses).
+--
 
-== Acknowledgments ==
-
+[.blue]#Acknowledgments#::
++
+--
 DAP4 is the result of a joint, multiyear development effort by OPeNDAP
 and Unidata, funded by a generous grant from NOAA and guided by an
 advisory committee comprising Mike Folk (THG), Jim Frew (UCSB), Steve
@@ -588,3 +608,4 @@ Hankin (NOAA), Eric Kihn (NOAA), Chris Lynnes (NASA) and Rich Signell
 
 Retrieved from
 https://docs.opendap.org/index.php?title=DAP4:_Overview&oldid=10530
+--


### PR DESCRIPTION
### The problem this PR tackles
Nesting in the `Overview.adoc` causes some errors when building the documentation.  This is described in #24. Despite this errors, the documentation builds fine...
With this PR, the following:

```
asciidoctor -a toc=left -a docinfo=shared  DAP4.adoc
```
No longer produces errors.




Nesting in `*.adoc` files is useful because it automatically creates anchors for those "sections". One anchor in the `Overview.adoc` file that is useful is the "section" that presents [Figure 1](https://opendap.github.io/dap4-specification/DAP4.html#_how_dap4_differs_from_dap2), describing (some of the) differences between DAP2 vs DAP4 data model. Both internal and external documentation point to that section/figure, and so removing the nesting in the Overview must be done is a way that preserves that anchor.


### PR changes
- [x] There are no longer nested sections within Overview.

In removing Nesting within `Overview.adoc`, this PR

- [x] Preserves the anchor to [Figure 1](https://opendap.github.io/dap4-specification/DAP4.html#_how_dap4_differs_from_dap2)
- [x] Adds the color blue to previously "nested" title sections for ease of readability (nesting assigns the color red). Before there were 6 subsections within the Overview: "Data Retrieval as ..", "Understanding the DAP ...", "Client Use of a DAP...", "The Formal DAP Specification", "How DAP4 differs from ...", and "Acknowledgements". These 6 should appear in color blue now. 


### For visual test / comparison between this PR and the previous build documentation

This PR will trigger Travis to build the documentation and push it to Gh-pages automatically. This means that going to the "published" official documentation [here](https://opendap.github.io/dap4-specification/DAP4.html) will show the PR changes already implemented. 

To compare against the previous build, the reviewer of this PR will have to build locally the documentation. This means having a local clone, and running the following two lines on the terminal (assuming you are located inside the cloned directory)

```
asciidoctor -a toc=left -a docinfo=shared  DAP4.adoc
open DAP4.html
```

 


