### PR TITLE
Specify that the computation of checksums includes counts.

### DIFF
--- a/01_data-model-and-serialized-rep.adoc
+++ b/01_data-model-and-serialized-rep.adoc
@@ -1559,11 +1559,6 @@ The checksum is made visible to the client by adding an attribute to
 each top-level variable in the DMR. This attribute is named
 "`_DAP4_Checksum_CRC32`".
 
-In all cases, the checksum is computed over the serialized
-representation of each top-level variable. The checksum is computed
-before any chunking Section link:#_dap4_chunked_data_representation[[1.7]])
-is applied.
-
 If the request to the server is a dmr-only request, then the server will
 compute the checksum for each variable mentioned in the DMR and will
 insert the "`_DAP4_Checksum_CRC32`" attribute in the DMR. Note that this
@@ -1582,6 +1577,20 @@ inserted in the serialization will be a 32 bit integer. The checksum
 integer will use the same endian representation as for the all other
 data. Note that CRC32 is not a cryptographically strong checksum, so it
 is not suitable for detecting man-in-the-middle attacks.
+
+==== Computing Checksums ====
+
+On the server side, the checksum is computed before any chunking
+Section link:#_dap4_chunked_data_representation[[1.7]]) is
+applied. On the client side, the checksum is computed after any
+chunking is removed from the response.
+
+The checksum is computed over the whole serialized
+representation of each top-level variable. This means
+specifically that the counts for variable-length variables
+are included in the checksum. A variable is variable length
+if it's type is String type or is Sequence type, or is a Structure type
+that has variable-length fields.
 
 _[#Historical_Note]#Historical Note#_
 


### PR DESCRIPTION
re: Issue https://github.com/OPENDAP/dap4-specification/issues/33
re: Discussion https://github.com/OPENDAP/dap4-specification/discussions/6
re: PR https://github.com/OPENDAP/dap4-specification/pull/34

Modify the checksum section to add a specific subsection on how the checksum is computed. This specifies that the computation specifically include the counts for variable-length data (Strings, Sequences, and Structs with variable-length fields).