### PR TITLE
fix upper camel case in main text or code block for OtherXML

### DIFF
--- a/01_data-model-and-serialized-rep.adoc
+++ b/01_data-model-and-serialized-rep.adoc
@@ -1157,13 +1157,13 @@ The form on an other XML declaration is as follows.
 
 [source,xml]
 ----
-<otherXML name="name">
+<OtherXML name="name">
 {arbitrary xml}
-</otherXML>
+</OtherXML>
 ----
 
-There are no `<value/>` elements because the value of otherXML is the xml
-inside the `<otherXML>…</otherXML>`. The text content of the otherXML
+There are no `<Value/>` elements because the value of the OtherXML element is the xml
+inside the `<OtherXML>…</OtherXML>`. The text content of the OtherXML
 element must be valid XML and must be distinct from the XML markup used
 to encode elements of the DAP4 data model (i.e., in a practical sense,
 the content of an `<OtherXML>` attribute will be in a namespace other than


### PR DESCRIPTION
This PR

- [x] Fixes mixed grammar described in #40. 
- [x] Leaves text unchanged when`otherxml` is being used in [1.10.2 Appendix 2 DAP4 Relax NG](https://opendap.github.io/dap4-specification/DAP4.html#_appendix_2_dap4_relax_ng_lexical_elements), and [1.10.5 Appendix 5 LALR Grammar for using Bison Notation](https://opendap.github.io/dap4-specification/DAP4.html#_appendix_5_lalr1_grammar_for_dmr_using_bison_notation)